### PR TITLE
Update requirements.txt to avoid version conflicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Sphinx
-sphinx_rtd_theme
+sphinx_rtd_theme>=2.0
 sphinx_rtd_theme_ext_color_contrast
 myst_nb
 sphinx-lesson


### PR DESCRIPTION
Pinning a minimum version of `sphinx-rtd-theme >= 2.0.0` mitigate from getting old version of sphinx-rtd-theme.

https://github.com/readthedocs/sphinx_rtd_theme/issues/1571#issuecomment-2263743320