### PR TITLE
Update LICENSE.code

### DIFF
--- a/LICENSE.code
+++ b/LICENSE.code
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }} and individual contributors.
+Copyright (c) 2024, ENCCS and individual contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Remove cookiecutter template syntax from license, since apparently cookiecutter is no longer used?